### PR TITLE
Update statements.mdx with warning over iterating members of a struct

### DIFF
--- a/pages/book/statements.mdx
+++ b/pages/book/statements.mdx
@@ -280,6 +280,15 @@ dump(sum); // 1000
   }
   ```
 
+In a similar way, trying to iterate over a member of a struct won't work:
+
+  ```tact
+  foreach (k, v in myStruct.myMap) {
+  //               ^ this will give a rather cryptic error message:
+  //                 Syntax error: expected ")"
+  }
+  ```
+
 </Callout>
 
 <Callout>


### PR DESCRIPTION
Based on this interation today on the Tact tg group:

![image](https://github.com/vitorpy/tact-docs/assets/12871/fe322d72-05f0-4cee-829c-26e3e3922c99)
